### PR TITLE
build: use generator specific build files instead of workspace_info

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,11 +1,11 @@
-load("//:workspace_info.bzl", "all_projects")
+load("//:csharp_metadata.bzl", "csharp_projects")
 
 filegroup(
     name = 'build_all',
-    srcs = ["{}:{}.dll".format(project, project.split('/')[-1]) for project in all_projects]
+    srcs = ["{}:{}.dll".format(project, project.split('/')[-1]) for project in csharp_projects]
 )
 
-deploy_commands = ['''echo "bazel run %s:deploy" --define version=$(version)>> $@''' % project for project in all_projects]
+deploy_commands = ['''echo "bazel run %s:deploy" --define version=$(version)>> $@''' % project for project in csharp_projects]
 genrule(
     name = 'publish_all',
     outs = ['publish_all.sh'],

--- a/scripts/nuget_deps.bzl
+++ b/scripts/nuget_deps.bzl
@@ -1,5 +1,5 @@
 load("@io_bazel_rules_dotnet//dotnet:defs.bzl", "nuget_package")
-load("//:workspace_info.bzl", "PROTOBUF_VERSION")
+load("//:csharp_metadata.bzl", "PROTOBUF_VERSION")
 
 def saltoapis_nuget_dependencies():
     """Adds nuget dependency repositories.


### PR DESCRIPTION
The workspace_info file is deprecated and will be removed in the near
future.