### PR TITLE
auth: add scopes on token request and a parameter customize them

### DIFF
--- a/src/Saltoapis.Auth/SaltoapisAuthInterceptor.cs
+++ b/src/Saltoapis.Auth/SaltoapisAuthInterceptor.cs
@@ -52,9 +52,9 @@ namespace Saltoapis.Auth
     {
         OAuthClientCredentialsProvider OAuthClient;
 
-        public SaltoapisAuthInterceptor(String id, String secret)
+        public SaltoapisAuthInterceptor(String id, String secret, String[] scopes)
         {
-            this.OAuthClient = new SaltoOAuthClient(id, secret);
+            this.OAuthClient = new SaltoOAuthClient(id, secret, scopes);
         }
 
         public SaltoapisAuthInterceptor(OAuthClientCredentialsProvider credentialsProvider)


### PR DESCRIPTION
The requested scopes can be customised. When unset, the default scopes will be requested: `openid`, `offline`, `https://saltoapis.com/auth/nebula`.