### PR TITLE
*: update outdated references to developer portal

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ var invoker = ChannelExtensions.Intercept(channel, authInterceptor);
 var service = new UserService.UserServiceClient(invoker);
 ```
 
-You can find more information about authentication at https://developer.saltosystems.com/api/authentication/.
+You can find more information about authentication at https://developer.saltosystems.com/nebula/api/authentication/.
 
 ## Setup
 

--- a/rules.bzl
+++ b/rules.bzl
@@ -37,7 +37,7 @@ def load_rules(lib_name, internal_dependencies, extra_info):
         deps = lib_deps + third_party_deps + ["@core_sdk_stdlib//:libraryset"],
     )
 
-    project_description = "Contains the SDK related to '%s'. Check out https://developer.saltonebula.com/ for more information" % lib_name
+    project_description = "Contains the SDK related to '%s'. Check out https://developer.saltosystems.com/ for more information" % lib_name
     if 'nuget_description' in extra_info:
         project_description = extra_info['nuget_description']
     # package will use version from 'csharp_library' by default 


### PR DESCRIPTION
The endpoints we were pointing to were out of date. Things changed a lot
since the very begining of this project and now the strategy for the
developer portal is to have more than one product on it instead of
focusing on specialized domains per product.