### PR TITLE
.github: allow reading contents and writing packages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v2
       - name: init


### PR DESCRIPTION
We don't know yet what triggers the requirement of these kind of parameters on GitHub Actions but the reality is that they're missing and should be present.