### PR TITLE
auth: allow overriding discovery host

### DIFF
--- a/src/Saltoapis.Auth/SaltoapisClientCredentialsProvider.cs
+++ b/src/Saltoapis.Auth/SaltoapisClientCredentialsProvider.cs
@@ -88,19 +88,19 @@ namespace Saltoapis.Auth
     /// </summary>
     class SaltoOAuthClient : OAuthClientCredentialsProvider
     {
-        static readonly string discoveryUri = "https://account.saltosystems.com/.well-known/openid-configuration";
-
         OIDCConfiguration cachedOidcConfiguration; // refeshed every 24 hours
         DateTimeOffset oidcCacheExpiration;
 
         SaltoTokenResponse token;
 
+        readonly String   discoveryUri;
         readonly String   clientId;
         readonly String   clientSecret;
         readonly String[] scopes;
 
-        public SaltoOAuthClient(String id, String secret, String[] scopes)
+        public SaltoOAuthClient(String id, String secret, String[] scopes, String discoveryHost = "account.saltosystems.com")
         {
+            this.discoveryUri = string.Format("https://{0}/.well-known/openid-configuration", discoveryHost);
             this.clientId = id;
             this.clientSecret = secret;
             this.scopes = scopes;


### PR DESCRIPTION
This change allows overriding the discovery host which currently is hardcoded within the authentication package.

While being able to configure this parameter allow pointing to different environments (dev, QA, staging, whatever), we want to avoid changing the default behaviour. This is why the change have been develop using optional parameters as it doesn't break the current standard (production) behaviour while being more flexible in customizing the environment we want to use.