### PR TITLE
auth: make oauth client credential provider public

### DIFF
--- a/src/Saltoapis.Auth/SaltoapisClientCredentialsProvider.cs
+++ b/src/Saltoapis.Auth/SaltoapisClientCredentialsProvider.cs
@@ -86,7 +86,7 @@ namespace Saltoapis.Auth
     /// access token from the authorization server and stores it while it's still
     /// valid. When its close to expiration a new one will be automatically requested.
     /// </summary>
-    class SaltoOAuthClient : OAuthClientCredentialsProvider
+    public class SaltoOAuthClient : OAuthClientCredentialsProvider
     {
         OIDCConfiguration cachedOidcConfiguration; // refeshed every 24 hours
         DateTimeOffset oidcCacheExpiration;


### PR DESCRIPTION
This change allow SDK consumers to use our OAuth2 client by making it `public`. That was the idea behind the change proposed in #229 but we weren't aware that actually the base client wasn't accessible from the SDK users.