### PR TITLE
*: replace Grpc.Core with Grpc.Net.Client library

### DIFF
--- a/rules.bzl
+++ b/rules.bzl
@@ -23,7 +23,7 @@ def load_rules(lib_name, internal_dependencies, extra_info):
     
 
     third_party_deps = [
-        "@grpc.core//:lib",
+        "@grpc.net.client//:lib",
         "@google.protobuf//:lib",
         "@google.api.commonprotos//:lib",
     ]
@@ -31,10 +31,13 @@ def load_rules(lib_name, internal_dependencies, extra_info):
     if  'extra_deps' in extra_info:
         third_party_deps += extra_info['extra_deps'].split(',')
     
+    target_framework = "netstandard2.1"
+
     csharp_library(
         name = '%s.dll' % lib_name,
         srcs = native.glob(['*.cs']),
         deps = lib_deps + third_party_deps + ["@core_sdk_stdlib//:libraryset"],
+        target_framework = target_framework,
     )
 
     project_description = "Contains the SDK related to '%s'. Check out https://developer.saltosystems.com/ for more information" % lib_name
@@ -46,6 +49,7 @@ def load_rules(lib_name, internal_dependencies, extra_info):
         name = 'deploy',
         id = lib_name,
         description = project_description,
+        target_framework = target_framework,
         sources = native.glob(['*.cs']),
         deps = third_party_deps,
         internal_deps = lib_deps,

--- a/scripts/nuget_deps.bzl
+++ b/scripts/nuget_deps.bzl
@@ -1,5 +1,5 @@
 load("@io_bazel_rules_dotnet//dotnet:defs.bzl", "nuget_package")
-load("//:csharp_metadata.bzl", "PROTOBUF_VERSION")
+load("//:csharp_metadata.bzl", "PROTOBUF_VERSION", "GRPC_CSHARP_VERSION")
 
 def saltoapis_nuget_dependencies():
     """Adds nuget dependency repositories.
@@ -20,17 +20,27 @@ def saltoapis_nuget_dependencies():
 
         These commands will generate a WORKSPACE file that contains the 'nuget_package' definitions for the dependencies. 
 
-            $ bazel run @io_bazel_rules_dotnet//tools/nuget2bazel:nuget2bazel.exe -- add -p $(pwd)/.tmp Grpc.Core 2.34.0
+            $ bazel run @io_bazel_rules_dotnet//tools/nuget2bazel:nuget2bazel.exe -- add -p $(pwd)/.tmp Grpc.Core 2.34.0 # only used to run the test server
+            $ bazel run @io_bazel_rules_dotnet//tools/nuget2bazel:nuget2bazel.exe -- add -p $(pwd)/.tmp Grpc.Net.Client 2.61.0
             $ bazel run @io_bazel_rules_dotnet//tools/nuget2bazel:nuget2bazel.exe -- add -p $(pwd)/.tmp Google.Protobuf 3.14.0 # change to PROTOBUF_VERSION
             $ bazel run @io_bazel_rules_dotnet//tools/nuget2bazel:nuget2bazel.exe -- add -p $(pwd)/.tmp Google.Api.CommonProtos 2.2.0
 
-        We will copy those rules to this file, and then update the 'Google.Protobuf' version to match 'PROTOBUF_VERSION'. Also remember to delete
-        the sha256 to allow for automatic version upgrades:
+        We will copy those rules to this file, and then update the following:
+            - The 'Google.Protobuf' version to match 'PROTOBUF_VERSION'.
+            - The 'Grpc.Net.Client' verstion to match 'GRPC_CSHARP_VERSION'.
+        Also remember to delete the sha256 to allow for automatic version upgrades:
+            
             nuget_package(
                 name = "google.protobuf",
                 package = "google.protobuf",
-                version = PROTOBUF_VERSION,  # <--- Change this
-                sha256 = "c30b3..."          # <--- Delete this
+                version = "3.%s" % PROTOBUF_VERSION,  # <--- Change this
+                sha256 = "c30b3..."                   # <--- Delete this
+
+            nuget_package(
+                name = "Grpc.Net.Client",
+                package = "Grpc.Net.Client",
+                version = GRPC_CSHARP_VERSION,  # <--- Change this
+                sha256 = "c30b3..."             # <--- Delete this
     """
 
 
@@ -48,57 +58,10 @@ def saltoapis_nuget_dependencies():
         sha256 = "a9d49320581fda1b4f4be6212c68c01a22cdf228026099c20a8eabefcf90f9cf",
     )
     nuget_package(
-        name = "system.runtime.compilerservices.unsafe",
-        package = "system.runtime.compilerservices.unsafe",
-        version = "4.7.1",
-        sha256 = "52fca80d5f0ed286371cf1b519b039e9855dbf04c611f8d8479816d4eec82b85",
-        core_lib = {
-            "netcoreapp2.0": "lib/netcoreapp2.0/System.Runtime.CompilerServices.Unsafe.dll",
-            "netcoreapp2.1": "lib/netcoreapp2.0/System.Runtime.CompilerServices.Unsafe.dll",
-            "netcoreapp2.2": "lib/netcoreapp2.0/System.Runtime.CompilerServices.Unsafe.dll",
-            "netcoreapp3.0": "lib/netcoreapp2.0/System.Runtime.CompilerServices.Unsafe.dll",
-            "netcoreapp3.1": "lib/netcoreapp2.0/System.Runtime.CompilerServices.Unsafe.dll",
-            "net5.0": "lib/netcoreapp2.0/System.Runtime.CompilerServices.Unsafe.dll",
-            "net6.0": "lib/netcoreapp2.0/System.Runtime.CompilerServices.Unsafe.dll",
-        },
-        core_ref = {
-            "netcoreapp2.0": "ref/netstandard2.0/System.Runtime.CompilerServices.Unsafe.dll",
-            "netcoreapp2.1": "ref/netstandard2.0/System.Runtime.CompilerServices.Unsafe.dll",
-            "netcoreapp2.2": "ref/netstandard2.0/System.Runtime.CompilerServices.Unsafe.dll",
-            "netcoreapp3.0": "ref/netstandard2.0/System.Runtime.CompilerServices.Unsafe.dll",
-            "netcoreapp3.1": "ref/netstandard2.0/System.Runtime.CompilerServices.Unsafe.dll",
-            "net5.0": "ref/netstandard2.0/System.Runtime.CompilerServices.Unsafe.dll",
-            "net6.0": "ref/netstandard2.0/System.Runtime.CompilerServices.Unsafe.dll",
-        },
-        core_files = {
-            "netcoreapp2.0": [
-            "lib/netcoreapp2.0/System.Runtime.CompilerServices.Unsafe.dll",
-            ],
-            "netcoreapp2.1": [
-            "lib/netcoreapp2.0/System.Runtime.CompilerServices.Unsafe.dll",
-            ],
-            "netcoreapp2.2": [
-            "lib/netcoreapp2.0/System.Runtime.CompilerServices.Unsafe.dll",
-            ],
-            "netcoreapp3.0": [
-            "lib/netcoreapp2.0/System.Runtime.CompilerServices.Unsafe.dll",
-            ],
-            "netcoreapp3.1": [
-            "lib/netcoreapp2.0/System.Runtime.CompilerServices.Unsafe.dll",
-            ],
-            "net5.0": [
-            "lib/netcoreapp2.0/System.Runtime.CompilerServices.Unsafe.dll",
-            ],
-            "net6.0": [
-            "lib/netcoreapp2.0/System.Runtime.CompilerServices.Unsafe.dll",
-            ],
-        },
-    )
-    nuget_package(
         name = "system.memory",
         package = "system.memory",
-        version = "4.5.4",
-        sha256 = "dec0847f33b8823e4260672d97d657411461c00ada3107ec7bbcb32a845eeb91",
+        version = "4.5.5",
+        sha256 = "10f43da352a29fb2b3188e4edd4dcf5100194c8b526e4f61fe2e2b5623775a22",
         core_lib = {
             "netcoreapp2.0": "lib/netstandard2.0/System.Memory.dll",
         },
@@ -116,8 +79,8 @@ def saltoapis_nuget_dependencies():
     nuget_package(
         name = "grpc.core.api",
         package = "grpc.core.api",
-        version = "2.46.1",
-        sha256 = "d5df912e3342bdddd9600289e07aea695cc2ca956444e535fd851078d8563464",
+        version = "2.61.0",
+        sha256 = "5c0b145e0c0bd33dbc222ef42394e0f0469a7cfa8b6a4f5b556a2cd56d6b9b5e",
         core_lib = {
             "netcoreapp2.0": "lib/netstandard2.0/Grpc.Core.Api.dll",
             "netcoreapp2.1": "lib/netstandard2.0/Grpc.Core.Api.dll",
@@ -136,18 +99,6 @@ def saltoapis_nuget_dependencies():
             ],
             "netcoreapp2.2": [
             "@system.memory//:netcoreapp2.2_core",
-            ],
-            "netcoreapp3.0": [
-            "@system.memory//:netcoreapp3.0_core",
-            ],
-            "netcoreapp3.1": [
-            "@system.memory//:netcoreapp3.1_core",
-            ],
-            "net5.0": [
-            "@system.memory//:net5.0_core",
-            ],
-            "net6.0": [
-            "@system.memory//:net6.0_core",
             ],
         },
         core_files = {
@@ -267,6 +218,360 @@ def saltoapis_nuget_dependencies():
             "lib/netstandard2.0/Grpc.Core.pdb",
             "runtimes/linux-x64/native/libgrpc_csharp_ext.x64.so",
             "runtimes/osx-x64/native/libgrpc_csharp_ext.x64.dylib",
+            ],
+        },
+    )
+    nuget_package(
+        name = "system.runtime.compilerservices.unsafe",
+        package = "system.runtime.compilerservices.unsafe",
+        version = "6.0.0",
+        sha256 = "6c41b53e70e9eee298cff3a02ce5acdd15b04125589be0273f0566026720a762",
+        core_lib = {
+            "netcoreapp2.0": "lib/netstandard2.0/System.Runtime.CompilerServices.Unsafe.dll",
+            "netcoreapp2.1": "lib/netstandard2.0/System.Runtime.CompilerServices.Unsafe.dll",
+            "netcoreapp2.2": "lib/netstandard2.0/System.Runtime.CompilerServices.Unsafe.dll",
+            "netcoreapp3.0": "lib/netstandard2.0/System.Runtime.CompilerServices.Unsafe.dll",
+            "netcoreapp3.1": "lib/netcoreapp3.1/System.Runtime.CompilerServices.Unsafe.dll",
+            "net5.0": "lib/netcoreapp3.1/System.Runtime.CompilerServices.Unsafe.dll",
+            "net6.0": "lib/net6.0/System.Runtime.CompilerServices.Unsafe.dll",
+        },
+        core_files = {
+            "netcoreapp2.0": [
+            "lib/netstandard2.0/System.Runtime.CompilerServices.Unsafe.dll",
+            ],
+            "netcoreapp2.1": [
+            "lib/netstandard2.0/System.Runtime.CompilerServices.Unsafe.dll",
+            ],
+            "netcoreapp2.2": [
+            "lib/netstandard2.0/System.Runtime.CompilerServices.Unsafe.dll",
+            ],
+            "netcoreapp3.0": [
+            "lib/netstandard2.0/System.Runtime.CompilerServices.Unsafe.dll",
+            ],
+            "netcoreapp3.1": [
+            "lib/netcoreapp3.1/System.Runtime.CompilerServices.Unsafe.dll",
+            ],
+            "net5.0": [
+            "lib/netcoreapp3.1/System.Runtime.CompilerServices.Unsafe.dll",
+            ],
+            "net6.0": [
+            "lib/net6.0/System.Runtime.CompilerServices.Unsafe.dll",
+            ],
+        },
+    )
+    nuget_package(
+        name = "grpc.net.common",
+        package = "grpc.net.common",
+        version = "2.61.0",
+        sha256 = "8a994bf86ea9bd48cae877e0bf573fa9058236aaf874af437c646be85ecbb630",
+        core_lib = {
+            "netcoreapp2.0": "lib/netstandard2.0/Grpc.Net.Common.dll",
+            "netcoreapp2.1": "lib/netstandard2.0/Grpc.Net.Common.dll",
+            "netcoreapp2.2": "lib/netstandard2.0/Grpc.Net.Common.dll",
+            "netcoreapp3.0": "lib/netstandard2.1/Grpc.Net.Common.dll",
+            "netcoreapp3.1": "lib/netstandard2.1/Grpc.Net.Common.dll",
+            "net5.0": "lib/netstandard2.1/Grpc.Net.Common.dll",
+            "net6.0": "lib/net6.0/Grpc.Net.Common.dll",
+        },
+        core_deps = {
+            "netcoreapp2.0": [
+            "@grpc.core.api//:netcoreapp2.0_core",
+            ],
+            "netcoreapp2.1": [
+            "@grpc.core.api//:netcoreapp2.1_core",
+            ],
+            "netcoreapp2.2": [
+            "@grpc.core.api//:netcoreapp2.2_core",
+            ],
+            "netcoreapp3.0": [
+            "@grpc.core.api//:netcoreapp3.0_core",
+            ],
+            "netcoreapp3.1": [
+            "@grpc.core.api//:netcoreapp3.1_core",
+            ],
+            "net5.0": [
+            "@grpc.core.api//:net5.0_core",
+            ],
+            "net6.0": [
+            "@grpc.core.api//:net6.0_core",
+            ],
+        },
+        core_files = {
+            "netcoreapp2.0": [
+            "lib/netstandard2.0/Grpc.Net.Common.dll",
+            "lib/netstandard2.0/Grpc.Net.Common.pdb",
+            ],
+            "netcoreapp2.1": [
+            "lib/netstandard2.0/Grpc.Net.Common.dll",
+            "lib/netstandard2.0/Grpc.Net.Common.pdb",
+            ],
+            "netcoreapp2.2": [
+            "lib/netstandard2.0/Grpc.Net.Common.dll",
+            "lib/netstandard2.0/Grpc.Net.Common.pdb",
+            ],
+            "netcoreapp3.0": [
+            "lib/netstandard2.1/Grpc.Net.Common.dll",
+            "lib/netstandard2.1/Grpc.Net.Common.pdb",
+            ],
+            "netcoreapp3.1": [
+            "lib/netstandard2.1/Grpc.Net.Common.dll",
+            "lib/netstandard2.1/Grpc.Net.Common.pdb",
+            ],
+            "net5.0": [
+            "lib/netstandard2.1/Grpc.Net.Common.dll",
+            "lib/netstandard2.1/Grpc.Net.Common.pdb",
+            ],
+            "net6.0": [
+            "lib/net6.0/Grpc.Net.Common.dll",
+            "lib/net6.0/Grpc.Net.Common.pdb",
+            ],
+        },
+    )
+    nuget_package(
+        name = "microsoft.extensions.logging.abstractions",
+        package = "microsoft.extensions.logging.abstractions",
+        version = "6.0.4",
+        sha256 = "966ba9809b3d3cdce931f7b52dcc58f74dd2e8bc22691f199be74e2bb25a4d5e",
+        core_lib = {
+            "netcoreapp2.0": "lib/netstandard2.0/Microsoft.Extensions.Logging.Abstractions.dll",
+            "netcoreapp2.1": "lib/netstandard2.0/Microsoft.Extensions.Logging.Abstractions.dll",
+            "netcoreapp2.2": "lib/netstandard2.0/Microsoft.Extensions.Logging.Abstractions.dll",
+            "netcoreapp3.0": "lib/netstandard2.0/Microsoft.Extensions.Logging.Abstractions.dll",
+            "netcoreapp3.1": "lib/netstandard2.0/Microsoft.Extensions.Logging.Abstractions.dll",
+            "net5.0": "lib/netstandard2.0/Microsoft.Extensions.Logging.Abstractions.dll",
+            "net6.0": "lib/net6.0/Microsoft.Extensions.Logging.Abstractions.dll",
+        },
+        core_deps = {
+            "netcoreapp2.0": [
+            "@system.buffers//:netcoreapp2.0_core",
+            "@system.memory//:netcoreapp2.0_core",
+            ],
+            "netcoreapp2.1": [
+            "@system.buffers//:netcoreapp2.1_core",
+            "@system.memory//:netcoreapp2.1_core",
+            ],
+            "netcoreapp2.2": [
+            "@system.buffers//:netcoreapp2.2_core",
+            "@system.memory//:netcoreapp2.2_core",
+            ],
+            "netcoreapp3.0": [
+            "@system.buffers//:netcoreapp3.0_core",
+            "@system.memory//:netcoreapp3.0_core",
+            ],
+            "netcoreapp3.1": [
+            "@system.buffers//:netcoreapp3.1_core",
+            "@system.memory//:netcoreapp3.1_core",
+            ],
+            "net5.0": [
+            "@system.buffers//:net5.0_core",
+            "@system.memory//:net5.0_core",
+            ],
+        },
+        core_files = {
+            "netcoreapp2.0": [
+            "lib/netstandard2.0/Microsoft.Extensions.Logging.Abstractions.dll",
+            ],
+            "netcoreapp2.1": [
+            "lib/netstandard2.0/Microsoft.Extensions.Logging.Abstractions.dll",
+            ],
+            "netcoreapp2.2": [
+            "lib/netstandard2.0/Microsoft.Extensions.Logging.Abstractions.dll",
+            ],
+            "netcoreapp3.0": [
+            "lib/netstandard2.0/Microsoft.Extensions.Logging.Abstractions.dll",
+            ],
+            "netcoreapp3.1": [
+            "lib/netstandard2.0/Microsoft.Extensions.Logging.Abstractions.dll",
+            ],
+            "net5.0": [
+            "lib/netstandard2.0/Microsoft.Extensions.Logging.Abstractions.dll",
+            ],
+            "net6.0": [
+            "lib/net6.0/Microsoft.Extensions.Logging.Abstractions.dll",
+            ],
+        },
+    )
+    nuget_package(
+        name = "system.diagnostics.diagnosticsource",
+        package = "system.diagnostics.diagnosticsource",
+        version = "6.0.1",
+        sha256 = "5e2f30ad48d5962a33fff4cf423147a9c57f406853aa74df51c96db0d95c089e",
+        core_lib = {
+            "netcoreapp2.0": "lib/netstandard2.0/System.Diagnostics.DiagnosticSource.dll",
+            "netcoreapp2.1": "lib/netstandard2.0/System.Diagnostics.DiagnosticSource.dll",
+            "netcoreapp2.2": "lib/netstandard2.0/System.Diagnostics.DiagnosticSource.dll",
+            "netcoreapp3.0": "lib/netstandard2.0/System.Diagnostics.DiagnosticSource.dll",
+            "netcoreapp3.1": "lib/netstandard2.0/System.Diagnostics.DiagnosticSource.dll",
+            "net5.0": "lib/net5.0/System.Diagnostics.DiagnosticSource.dll",
+            "net6.0": "lib/net6.0/System.Diagnostics.DiagnosticSource.dll",
+        },
+        core_deps = {
+            "netcoreapp2.0": [
+            "@system.runtime.compilerservices.unsafe//:netcoreapp2.0_core",
+            "@system.memory//:netcoreapp2.0_core",
+            ],
+            "netcoreapp2.1": [
+            "@system.runtime.compilerservices.unsafe//:netcoreapp2.1_core",
+            "@system.memory//:netcoreapp2.1_core",
+            ],
+            "netcoreapp2.2": [
+            "@system.runtime.compilerservices.unsafe//:netcoreapp2.2_core",
+            "@system.memory//:netcoreapp2.2_core",
+            ],
+            "netcoreapp3.0": [
+            "@system.runtime.compilerservices.unsafe//:netcoreapp3.0_core",
+            "@system.memory//:netcoreapp3.0_core",
+            ],
+            "netcoreapp3.1": [
+            "@system.runtime.compilerservices.unsafe//:netcoreapp3.1_core",
+            "@system.memory//:netcoreapp3.1_core",
+            ],
+            "net5.0": [
+            "@system.runtime.compilerservices.unsafe//:net5.0_core",
+            ],
+            "net6.0": [
+            "@system.runtime.compilerservices.unsafe//:net6.0_core",
+            ],
+        },
+        core_files = {
+            "netcoreapp2.0": [
+            "lib/netstandard2.0/System.Diagnostics.DiagnosticSource.dll",
+            ],
+            "netcoreapp2.1": [
+            "lib/netstandard2.0/System.Diagnostics.DiagnosticSource.dll",
+            ],
+            "netcoreapp2.2": [
+            "lib/netstandard2.0/System.Diagnostics.DiagnosticSource.dll",
+            ],
+            "netcoreapp3.0": [
+            "lib/netstandard2.0/System.Diagnostics.DiagnosticSource.dll",
+            ],
+            "netcoreapp3.1": [
+            "lib/netstandard2.0/System.Diagnostics.DiagnosticSource.dll",
+            ],
+            "net5.0": [
+            "lib/net5.0/System.Diagnostics.DiagnosticSource.dll",
+            ],
+            "net6.0": [
+            "lib/net6.0/System.Diagnostics.DiagnosticSource.dll",
+            ],
+        },
+    )
+    nuget_package(
+        name = "system.net.http.winhttphandler",
+        package = "system.net.http.winhttphandler",
+        version = "7.0.0",
+        sha256 = "66bd4708ee28eda93b9799bbf5313e8487f5f6cecf7e5a7e36ae16c9c02ba3f4",
+        core_lib = {
+            "netcoreapp2.0": "lib/netstandard2.0/System.Net.Http.WinHttpHandler.dll",
+            "netcoreapp2.1": "lib/netstandard2.0/System.Net.Http.WinHttpHandler.dll",
+            "netcoreapp2.2": "lib/netstandard2.0/System.Net.Http.WinHttpHandler.dll",
+            "netcoreapp3.0": "lib/netstandard2.0/System.Net.Http.WinHttpHandler.dll",
+            "netcoreapp3.1": "lib/netstandard2.0/System.Net.Http.WinHttpHandler.dll",
+            "net5.0": "lib/netstandard2.0/System.Net.Http.WinHttpHandler.dll",
+            "net6.0": "lib/net6.0/System.Net.Http.WinHttpHandler.dll",
+        },
+        core_files = {
+            "netcoreapp2.0": [
+            "lib/netstandard2.0/System.Net.Http.WinHttpHandler.dll",
+            ],
+            "netcoreapp2.1": [
+            "lib/netstandard2.0/System.Net.Http.WinHttpHandler.dll",
+            ],
+            "netcoreapp2.2": [
+            "lib/netstandard2.0/System.Net.Http.WinHttpHandler.dll",
+            ],
+            "netcoreapp3.0": [
+            "lib/netstandard2.0/System.Net.Http.WinHttpHandler.dll",
+            ],
+            "netcoreapp3.1": [
+            "lib/netstandard2.0/System.Net.Http.WinHttpHandler.dll",
+            ],
+            "net5.0": [
+            "lib/netstandard2.0/System.Net.Http.WinHttpHandler.dll",
+            ],
+            "net6.0": [
+            "lib/net6.0/System.Net.Http.WinHttpHandler.dll",
+            ],
+        },
+    )
+    nuget_package(
+        name = "grpc.net.client",
+        package = "grpc.net.client",
+        version = GRPC_CSHARP_VERSION,
+        core_lib = {
+            "netcoreapp2.0": "lib/netstandard2.0/Grpc.Net.Client.dll",
+            "netcoreapp2.1": "lib/netstandard2.0/Grpc.Net.Client.dll",
+            "netcoreapp2.2": "lib/netstandard2.0/Grpc.Net.Client.dll",
+            "netcoreapp3.0": "lib/netstandard2.1/Grpc.Net.Client.dll",
+            "netcoreapp3.1": "lib/netstandard2.1/Grpc.Net.Client.dll",
+            "net5.0": "lib/netstandard2.1/Grpc.Net.Client.dll",
+            "net6.0": "lib/net6.0/Grpc.Net.Client.dll",
+        },
+        core_deps = {
+            "netcoreapp2.0": [
+            "@grpc.net.common//:netcoreapp2.0_core",
+            "@microsoft.extensions.logging.abstractions//:netcoreapp2.0_core",
+            "@system.diagnostics.diagnosticsource//:netcoreapp2.0_core",
+            ],
+            "netcoreapp2.1": [
+            "@grpc.net.common//:netcoreapp2.1_core",
+            "@microsoft.extensions.logging.abstractions//:netcoreapp2.1_core",
+            "@system.diagnostics.diagnosticsource//:netcoreapp2.1_core",
+            ],
+            "netcoreapp2.2": [
+            "@grpc.net.common//:netcoreapp2.2_core",
+            "@microsoft.extensions.logging.abstractions//:netcoreapp2.2_core",
+            "@system.diagnostics.diagnosticsource//:netcoreapp2.2_core",
+            ],
+            "netcoreapp3.0": [
+            "@grpc.net.common//:netcoreapp3.0_core",
+            "@microsoft.extensions.logging.abstractions//:netcoreapp3.0_core",
+            "@system.diagnostics.diagnosticsource//:netcoreapp3.0_core",
+            ],
+            "netcoreapp3.1": [
+            "@grpc.net.common//:netcoreapp3.1_core",
+            "@microsoft.extensions.logging.abstractions//:netcoreapp3.1_core",
+            "@system.diagnostics.diagnosticsource//:netcoreapp3.1_core",
+            ],
+            "net5.0": [
+            "@grpc.net.common//:net5.0_core",
+            "@microsoft.extensions.logging.abstractions//:net5.0_core",
+            "@system.diagnostics.diagnosticsource//:net5.0_core",
+            ],
+            "net6.0": [
+            "@grpc.net.common//:net6.0_core",
+            "@microsoft.extensions.logging.abstractions//:net6.0_core",
+            ],
+        },
+        core_files = {
+            "netcoreapp2.0": [
+            "lib/netstandard2.0/Grpc.Net.Client.dll",
+            "lib/netstandard2.0/Grpc.Net.Client.pdb",
+            ],
+            "netcoreapp2.1": [
+            "lib/netstandard2.0/Grpc.Net.Client.dll",
+            "lib/netstandard2.0/Grpc.Net.Client.pdb",
+            ],
+            "netcoreapp2.2": [
+            "lib/netstandard2.0/Grpc.Net.Client.dll",
+            "lib/netstandard2.0/Grpc.Net.Client.pdb",
+            ],
+            "netcoreapp3.0": [
+            "lib/netstandard2.1/Grpc.Net.Client.dll",
+            "lib/netstandard2.1/Grpc.Net.Client.pdb",
+            ],
+            "netcoreapp3.1": [
+            "lib/netstandard2.1/Grpc.Net.Client.dll",
+            "lib/netstandard2.1/Grpc.Net.Client.pdb",
+            ],
+            "net5.0": [
+            "lib/netstandard2.1/Grpc.Net.Client.dll",
+            "lib/netstandard2.1/Grpc.Net.Client.pdb",
+            ],
+            "net6.0": [
+            "lib/net6.0/Grpc.Net.Client.dll",
+            "lib/net6.0/Grpc.Net.Client.pdb",
             ],
         },
     )

--- a/scripts/package.csproj.tmpl
+++ b/scripts/package.csproj.tmpl
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>{target_framework}</TargetFramework>
         
         <Authors>SALTO Systems S.L.</Authors>
         <Company>SALTO Systems S.L.</Company>

--- a/scripts/release.bzl
+++ b/scripts/release.bzl
@@ -51,7 +51,7 @@ def _nuget_deploy(ctx):
             cd "{project_folder}"
             dotnet restore
             dotnet pack --configuration Release {package_args}
-            dotnet nuget push "bin/Release/{id}.{version}.nupkg" --source "github"
+            dotnet nuget push "bin/Release/{id}.{version}.nupkg" --skip-duplicate --source "github"
         '''.format(
             project_folder = csproj_file.short_path.split(csproj_file.basename)[0],
             package_args = ' '.join(package_args),
@@ -78,6 +78,9 @@ nuget_deploy = rule(
         ),
         'sources': attr.label_list(
             allow_files = True,
+        ),
+        'target_framework': attr.string(
+            default = 'netstandard2.1',
         ),
         'internal_deps': attr.label_list(
             doc = """
@@ -138,6 +141,7 @@ def _create_csproj_file(csproj_file, internal_version, ctx):
         substitutions = {
             '{id}': id,
             '{description}': ctx.attr.description,
+            '{target_framework}': ctx.attr.target_framework,
             '{version}': internal_version,
             '{dependencies}': "\n        ".join(dependencies),
         }

--- a/src/Saltoapis.Auth.Tests/BUILD
+++ b/src/Saltoapis.Auth.Tests/BUILD
@@ -9,7 +9,8 @@ csharp_nunit3_test(
     ],
     deps = [
         '//src/Saltoapis.Auth:Saltoapis.Auth.dll',
-
         "@nunit//:lib",
+        # required to create the testing server
+        '@grpc.core//:lib',
     ],
 )


### PR DESCRIPTION
The generated code works with both libraries. `Grpc.Core` is the original gRPC library implemented in C. This is already deprecated in favor of `Grpc.Net.Client`, a new implementation written purely in C#.

The commit also changes the target framework from netcoreapp3.1 to netstandard2.1 which is less specific and should increase the project compatibility.

The `Grpc.Core` dependency is still required to run the Auth tests to setup the testing gRPC server.