### PR TITLE
build: use netstandard2.0 as target framework

### DIFF
--- a/rules.bzl
+++ b/rules.bzl
@@ -31,7 +31,7 @@ def load_rules(lib_name, internal_dependencies, extra_info):
     if  'extra_deps' in extra_info:
         third_party_deps += extra_info['extra_deps']
     
-    target_framework = "netstandard2.1"
+    target_framework = "netstandard2.0"
 
     csharp_library(
         name = '%s.dll' % lib_name,

--- a/scripts/release.bzl
+++ b/scripts/release.bzl
@@ -80,7 +80,7 @@ nuget_deploy = rule(
             allow_files = True,
         ),
         'target_framework': attr.string(
-            default = 'netstandard2.1',
+            default = 'netstandard2.0',
         ),
         'internal_deps': attr.label_list(
             doc = """


### PR DESCRIPTION
We need to support .NET Framework and .NET Standard 2.0 is the last version that allows this. For more information see: https://learn.microsoft.com/en-us/dotnet/standard/net-standard?tabs=net-standard-2-0#net-standard-versions